### PR TITLE
Add tool to convert users.json -> users.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,33 +9,36 @@ See `contributing.md`
 ## What
 
 This tool is for the maintenance of users and ssh keys for our
-operations.  The tool encodes data into a json file.  It can also use
+operations. The tool encodes data into a json file. It can also use
 the json file to change the current state of the system to include the
 users in the json file.
 
-Note the UID is the consistent thing between runs.  Never delete a UID
+Note the UID is the consistent thing between runs. Never delete a UID
 from the json file.
 
 # I Just Want to Add my SSH Key
 
-**AUTHORIZED_KEYS ARE YOUR PUBLIC KEYS OR KEY, NEVER A PRIVATE KEY**
+We use yubikey PIV slot 9e (Card Authentication) as our public keys. To get your public-key:
+`yubico-piv-tool -aread-cert -s9e -K SSH`
 
-**DO NOT COMMIT WITH GITHUB ENTERPRISE**
+This is the key to add for your authentication. It will require yubikey pin + touch. Should you ever loose your yubikey, notification of the Red Team is required.
 
 Run this or have a friend do it:
 
-1. ```git config user.name "<USERID>" && git config user.email "<EMAIL>"```
-1. ```user_tool.py add -j users.json -u '<USERID>' -n '<YOUR NAME>' -k <PATH OF AUTHROZIED_KEYS> [-t <tag>] [-t <tag>] [-s <shell>]```
-1. ```git add users.json```
-1. ```git commit -m 'adding <YOUR NAME>'```
-1. ```git push origin master```
+1. `git config user.name "<USERID>" && git config user.email "<EMAIL>"`
+2. `git branch -m master <USERID>`
+3. `python3 user_tool.py add -j users.json -u '<USERID>' -n '<YOUR NAME>' -k <PATH OF AUTHROZIED_KEYS> [-t <tag>] [-t <tag>] [-s <shell>]`
+4. `git add users.json`
+5. `git commit -m 'adding <YOUR NAME>'`
+6. `git push origin <USERID>`
 
 ## user attributes
-* uid
-* name
-* username
-* authorized_keys
-* tags
+
+- uid
+- name
+- username
+- authorized_keys
+- tags
 
 ### Tags
 
@@ -81,52 +84,65 @@ Multiple tags will be needed for some users in which case `-t` will be issued tw
 
 # Usage Modes
 
-* ```user_tool.py new -j <json_file>```
+- `user_tool.py new -j <json_file>`
 
 Create a new json file with no users in it
 
-* ```user_tool.py apply -j <json_file> -t <tag> [-t <tag>]```
+- `user_tool.py apply -j <json_file> -t <tag> [-t <tag>]`
 
 Make this system match the configuration in the json file
 
-* ```user_tool.py add -j <json_file> -n <name> -u <username> -k <authorized_keys_file> [-t <tag>] [-s <shell>]```
+- `user_tool.py add -j <json_file> -n <name> -u <username> -k <authorized_keys_file> [-t <tag>] [-s <shell>]`
 
-Add a user to the json file.  The allocated UID is returned.
+Add a user to the json file. The allocated UID is returned.
 
-* ```user_tool.py del -j <json_file> --uid <uid>```
+- `user_tool.py del -j <json_file> --uid <uid>`
 
-Deactivate a user from the json file.  This just clears the authorized keys.  Users are not deleted, but rather are unable to log in.
+Deactivate a user from the json file. This just clears the authorized keys. Users are not deleted, but rather are unable to log in.
 
-* ```user_tool.py mod -j <json_file> --uid <uid> [-n <name>] [-u <username>] [-k <authorized_keys_file>]  [-t <tag>]```
+- `user_tool.py mod -j <json_file> --uid <uid> [-n <name>] [-u <username>] [-k <authorized_keys_file>]  [-t <tag>]`
 
-Modify a user.  This can be name, keys, username, or tags.
+Modify a user. This can be name, keys, username, or tags.
 
 Add an ssh key for a user.
 
 1.  Find the authorized keys attribute in the users.json for the user in question and paste into a file called based.
-1.  ```cat based | base64 -d > authorized_keys```
+1.  `cat based | base64 -d > authorized_keys`
 1.  add your public key to authorized_keys
-1.  ```user_tool.py mod -j <json_file> --uid <uid> -k ./authorized_keys```
+1.  `user_tool.py mod -j <json_file> --uid <uid> -k ./authorized_keys`
+
+# json-ansible
+
+To create users with Ansible you can convert a populated `users.json` file with `json-ansible.py`. Simply run:
+
+```
+python3 json-ansible.py
+```
+
+A users.yml file will be created with the correct Ansible playbook format. You can copy this file into your infrastructure `ansible/users/users.yml`
+
+This is a temporary measure until a new method of manager users is developed.
 
 # sync_tool
 
-This tool is a script that is run via your internal host that syncronizes the ssh repo to homebases that are deployed in AWS.  This tool is executed every 30 minutes via cron as the sshsyncrobot user.  This user has a public key that is stored in the users.json such that it can push to AWS.  The shell for this user is git-shell, however.  Due to the way groups are done, which should probably be improved in the future, this user is a redteam user on homebase, which does give it sudo access.  However, git-shell keeps it from executing commands.  The invocation of this tool is similar to `user_tool.py` above.
+This tool is a script that is run via your internal host that syncronizes the ssh repo to homebases that are deployed in AWS. This tool is executed every 30 minutes via cron as the sshsyncrobot user. This user has a public key that is stored in the users.json such that it can push to AWS. The shell for this user is git-shell, however. Due to the way groups are done, which should probably be improved in the future, this user is a redteam user on homebase, which does give it sudo access. However, git-shell keeps it from executing commands. The invocation of this tool is similar to `user_tool.py` above.
 
-* Add a homebase
+- Add a homebase
 
-```sync_tool.py add -i <ipaddr>```
+`sync_tool.py add -i <ipaddr>`
 
-* Del a homebase
+- Del a homebase
 
-```sync_tool.py del -i <ipaddr>```
+`sync_tool.py del -i <ipaddr>`
 
-* Push to all the hosts in instances.json
+- Push to all the hosts in instances.json
 
 Note that this logs into syslog.
 
-```sync_tool.py push -k <keypath>```
+`sync_tool.py push -k <keypath>`
 
 ## Running Automatically
+
 Put the following in the sshsyncrobot user's crontab
 
-```*/30 * * * * ~/sync_tool.py push -k ~/.ssh/id_ed25519```
+`*/30 * * * * ~/sync_tool.py push -k ~/.ssh/id_ed25519`

--- a/json-ansible.py
+++ b/json-ansible.py
@@ -1,0 +1,73 @@
+import json
+import base64
+
+# read JSON
+with open('users.json', 'r') as json_file:
+    data = json.load(json_file)
+
+users = data['users']
+groups = set()
+
+# ansible playbook header
+playbook_content = """---
+- name: Ensure users are configured
+  hosts: all
+  become: true
+  tasks:
+    - name: allow group 'redteam' to sudo
+      copy:
+        dest: /etc/sudoers.d/redteam
+        owner: root
+        mode: 0600
+        content: |
+          %redteam ALL=(ALL) NOPASSWD:ALL
+    - name: Add groups
+      group:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - redteam
+"""
+
+for user in users:
+    for tag in user['tags']:
+        if tag != 'redteam':
+          groups.add(tag)
+
+# create the groups
+for group in groups:
+    playbook_content += f"""        - {group}\n"""
+
+
+for user in users:
+    if (len(user['authorized_keys']) > 0):
+        authorized_key = base64.b64decode(user['authorized_keys']).decode('utf-8')
+        user_groups = ', '.join([group for group in user['tags'] if not group == 'redteam']).strip()
+        playbook_content += f"""
+    - name: Add user {user['username']}
+      ansible.builtin.user:
+        name: {user['username']}
+        comment: "{user['name']}"
+        shell: {user['shell']}
+        uid: {user['uid']}
+        password: "*"
+        state: present
+        group: redteam
+        groups: {user_groups}
+
+    - name: Add ssh public key for {user['username']}
+      ansible.posix.authorized_key:
+        user: {user['username']}
+        state: present
+        exclusive: true
+        key: |
+          {authorized_key}
+"""
+
+# print(playbook_content)
+
+# write the playbook content to a YML file
+with open('users.yml', 'w') as playbook:
+    playbook.write(playbook_content)
+
+print("Ansible playbook 'users.yml' has been created.")


### PR DESCRIPTION
Adding tool to convert existing `users.json` files to `users.yml` that is required for standing up infrastructure after converting to Ansible. This is a temporary fix in lieu of rewriting `user_tool.py` right away.